### PR TITLE
[Translation] [Minor] Updating translation for addon

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -57,7 +57,7 @@
   "importSettings": "Import/Export all Settings",
   "saveSettings": "Save Settings as file",
   "uploadSettings": "Upload settings",
-  "resetAddon": "Reset Addon to default",
+  "resetAddon": "Reset addon to default",
   "noWrap": "nowrap",
   "watchCreditsSwitch": "Watch Credits:",
   "watchCreditsDescription": "Always watch the credits of every series",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -57,7 +57,7 @@
   "importSettings": "Importar/exportar todos los ajustes",
   "saveSettings": "Guardar configuración como archivo",
   "uploadSettings": "Cargar configuración",
-  "resetAddon": "Restablecer Addon por defecto",
+  "resetAddon": "Restablecer la extension por defecto",
   "noWrap": "nowrap",
   "watchCreditsSwitch": "Ver créditos:",
   "watchCreditsDescription": "Ver siempre los créditos de cada serie",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -57,7 +57,7 @@
   "importSettings": "Importer/exporter tous les paramètres",
   "saveSettings": "Enregistrer les paramètres dans un fichier",
   "uploadSettings": "Paramètres de téléchargement",
-  "resetAddon": "Réinitialiser l'addon",
+  "resetAddon": "Réinitialiser l'extension",
   "noWrap": "Nowrap",
   "watchCreditsSwitch": "Voir les crédits :",
   "watchCreditsDescription": "Toujours regarder le générique de chaque série",


### PR DESCRIPTION
Hello,
As both commit said :
[fix: removing capital letter of addon to make future translation easier]
> It seems Addon with a capital A is not well translated as it appears as a name.

[fix: translation of addon in french and spanish]
> We don't say addon but extension in both language.