### PR TITLE
fix(amazon): harden paid-content filter and add regression guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"format": "prettier --write .",
 		"lint": "eslint . --fix --cache",
 		"lint:manifest": "web-ext lint",
+		"test:amazon-filter": "tsx --test src/content-script/amazonFilterPaidGuard.test.ts",
 		"typecheck": "vue-tsc --noEmit",
 		"transGoogle": "jsontt .translation/deepl.EN.json -m google2 -n google2 -fb yes -cl 3 -f en -t de fr es pt it ja pl sv zh-CN ko tr",
 		"deepl": "jsontt .translation/deepl.EN.json -m deepl -n deepl -fb yes -cl 3 -f EN -t DE ES FR IT JA KO PL PT SV TR ZH",

--- a/src/content-script/amazonFilterPaidGuard.test.ts
+++ b/src/content-script/amazonFilterPaidGuard.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import {
+	isStoreIconTitle,
+	shouldRemoveWholePaidSection,
+	shouldRunAmazonPaidFilter,
+} from "./amazonFilterPaidGuard"
+
+test("shouldRunAmazonPaidFilter matches storefront and browse urls", () => {
+	assert.equal(shouldRunAmazonPaidFilter("https://www.primevideo.com/storefront/home"), true)
+	assert.equal(shouldRunAmazonPaidFilter("https://www.primevideo.com/movie/0ABC"), true)
+	assert.equal(shouldRunAmazonPaidFilter("https://www.primevideo.com/tv"), true)
+	assert.equal(shouldRunAmazonPaidFilter("https://www.primevideo.com/addons"), true)
+})
+
+test("shouldRunAmazonPaidFilter ignores detail pages", () => {
+	assert.equal(shouldRunAmazonPaidFilter("https://www.primevideo.com/detail/0ABC"), false)
+	assert.equal(shouldRunAmazonPaidFilter("https://www.primevideo.com/watch"), false)
+})
+
+test("isStoreIconTitle identifies paid icon labels", () => {
+	assert.equal(isStoreIconTitle("Store Filled"), true)
+	assert.equal(isStoreIconTitle("store"), true)
+	assert.equal(isStoreIconTitle("Prime"), false)
+	assert.equal(isStoreIconTitle(undefined), false)
+})
+
+test("shouldRemoveWholePaidSection follows current threshold rule", () => {
+	assert.equal(shouldRemoveWholePaidSection(8, 6), true)
+	assert.equal(shouldRemoveWholePaidSection(8, 5), false)
+	assert.equal(shouldRemoveWholePaidSection(2, 2), true)
+	assert.equal(shouldRemoveWholePaidSection(0, 0), false)
+})

--- a/src/content-script/amazonFilterPaidGuard.ts
+++ b/src/content-script/amazonFilterPaidGuard.ts
@@ -1,0 +1,14 @@
+const AMAZON_ALLOWED_FILTER_PATHS = /(storefront|genre|movie|amazon-video|\/tv|\/addons)/i
+
+export function shouldRunAmazonPaidFilter(url: string) {
+	return AMAZON_ALLOWED_FILTER_PATHS.test(url)
+}
+
+export function isStoreIconTitle(title: string | null | undefined) {
+	return /store/i.test(title ?? "")
+}
+
+export function shouldRemoveWholePaidSection(visibleCardsCount: number, paidCardsCount: number, bannerOffset = 2) {
+	if (visibleCardsCount <= 0 || paidCardsCount <= 0) return false
+	return visibleCardsCount - bannerOffset <= paidCardsCount
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -147,7 +147,12 @@ export default defineConfig({
 		rollupOptions: {
 			output: {
 				entryFileNames: "[name].js",
-				chunkFileNames: "[name].js",
+				chunkFileNames: (chunkInfo) => {
+					const chunkName = chunkInfo.name ?? "chunk"
+					// Chrome extensions reserve root filenames starting with "_".
+					const safeName = chunkName.replace(/^_+/, "")
+					return `${safeName}.js`
+				},
 				assetFileNames: "[name].[ext]",
 			},
 			// ui or pages that are not specified in manifest file need to be specified here

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,0 +1,28 @@
+# Walkthrough: Prime Video `Remove paid content` fix
+
+## What was fixed
+- Reworked Prime paid-content detection to use `article[data-card-entitlement="Unentitled"]` (stable marker).
+- Kept fallback detection for store icon markers (`svg.NbhXwl` and entitlement icon SVG title containing `store`).
+- Switched URL checks to use the live `window.location.href` each run (avoids stale startup URL issues in SPA navigation).
+- Added throttled debug logs when filtering is enabled but no paid markers are found.
+- Added a small regression guard module with unit tests for:
+  - eligible Prime URLs,
+  - paid store icon title detection,
+  - section-removal threshold logic.
+
+## Files changed
+- `src/content-script/amazon.ts`
+- `android-app/content-script/amazon.ts`
+- `src/content-script/amazonFilterPaidGuard.ts`
+- `src/content-script/amazonFilterPaidGuard.test.ts`
+- `package.json` (`test:amazon-filter`)
+
+## Validation steps
+1. Enable `Remove paid content` in extension settings.
+2. Open Prime Video storefront/home.
+3. Confirm rows or cards marked as paid are removed.
+4. Check console logs:
+   - Success logs: `Filtered paid category` / `Filtered paid Element`
+   - Debug log (if none found): `FilterPaid active but no paid markers found`
+5. Run automated regression check:
+   - `npm run test:amazon-filter`


### PR DESCRIPTION
## Summary
- Improve Prime Video paid-content removal reliability on storefront/browse pages.
- Add robust paid-marker detection (including store icon title fallback).
- Keep filtering active across SPA navigation.
- Add throttled debug logs when no paid markers are detected.
- Sanitize generated chunk names to avoid leading-underscore files in extension root (Chrome load restriction).

## Why
Prime paid rows/cards were intermittently visible. The previous logic was too brittle for current DOM/route behavior.

## Tests
- npm run test:amazon-filter
- npm run build:chrome
- npm run build:firefox

## Manual verification
- Prime storefront/home: paid rows and cards are hidden as expected.
