### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-streaming-service.md
+++ b/.github/ISSUE_TEMPLATE/new-streaming-service.md
@@ -13,7 +13,7 @@ Page: e.g. [https://www.starplus.com/](https://www.starplus.com/)
 definetly available in Country: USA e.g.
 
 ### Steps
-For each feature you want added, create a page snapshot with the add-on Single File ([Chrome](https://chrome.google.com/webstore/detail/singlefile/mpiodijhokgodhhofbcjdecpffjipkle) [Firefox](https://addons.mozilla.org/en-US/firefox/addon/single-file/)) and attach the files to the issue.
+For each feature you want added, create a page snapshot with the add-on Single File ([Chrome](https://chromewebstore.google.com/detail/singlefile/mpiodijhokgodhhofbcjdecpffjipkle) [Firefox](https://addons.mozilla.org/en-US/firefox/addon/single-file/)) and attach the files to the issue.
 
 Features that require a snapshot with single file:
 * Home Page

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <img alt="Mozilla Add-on Rating" src="https://img.shields.io/amo/rating/NetflixPrime%40Autoskip.io">
 </a>
 <br>
-<a href="https://chrome.google.com/webstore/detail/streaming-enhanced-netfli/akaimhgappllmlkadblbdknhbfghdgle">
+<a href="https://chromewebstore.google.com/detail/streaming-enhanced-netfli/akaimhgappllmlkadblbdknhbfghdgle">
 <img src="docs/Logos/chrome.svg" width="20px">
 <img src="https://img.shields.io/chrome-web-store/users/akaimhgappllmlkadblbdknhbfghdgle" >
 <img alt="Chrome Web Store Rating" src="https://img.shields.io/chrome-web-store/rating/akaimhgappllmlkadblbdknhbfghdgle">
@@ -31,7 +31,7 @@
 ## Download & Install
 
 <a href="https://addons.mozilla.org/firefox/addon/netflix-prime-auto-skip/"><img src="docs/Logos/download button/firefox.png" alt="Get Streaming enhanced for Firefox"/>
-<a href="https://chrome.google.com/webstore/detail/streaming-enhanced-netfli/akaimhgappllmlkadblbdknhbfghdgle"><img src="docs/Logos/download button/chrome.png" alt="Get Streaming enhanced for Chromium"/>
+<a href="https://chromewebstore.google.com/detail/streaming-enhanced-netfli/akaimhgappllmlkadblbdknhbfghdgle"><img src="docs/Logos/download button/chrome.png" alt="Get Streaming enhanced for Chromium"/>
 <a href="https://microsoftedge.microsoft.com/addons/detail/streaming-enhanced-netfli/dhfpagghjamocfaaignghcljfpppelff"><img src="docs/Logos/download button/microsoft.png" alt="Get Streaming enhanced for Edge"/>
 
 ## Install on Android

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -29,7 +29,7 @@ function openSettings() {
 				:href="
 					isFirefox
 						? 'https://addons.mozilla.org/firefox/addon/netflix-prime-auto-skip/'
-						: 'https://chrome.google.com/webstore/detail/netflixprime-auto-skip/akaimhgappllmlkadblbdknhbfghdgle'
+						: 'https://chromewebstore.google.com/detail/netflixprime-auto-skip/akaimhgappllmlkadblbdknhbfghdgle'
 				"
 			>
 				<p class="text-nowrap text-base p-0">

--- a/src/ui/options-page/app.vue
+++ b/src/ui/options-page/app.vue
@@ -163,7 +163,7 @@ watch(
 						:href="
 							isFirefox
 								? 'https://addons.mozilla.org/firefox/addon/netflix-prime-auto-skip/'
-								: 'https://chrome.google.com/webstore/detail/netflixprime-auto-skip/akaimhgappllmlkadblbdknhbfghdgle'
+								: 'https://chromewebstore.google.com/detail/netflixprime-auto-skip/akaimhgappllmlkadblbdknhbfghdgle'
 						"
 					>
 						<p class="text-base text-white">


### PR DESCRIPTION
Updates Chrome Web Store URLs from the deprecated `chrome.google.com/webstore` domain to `chromewebstore.google.com`.

Google has migrated the Chrome Web Store to the new domain. The old URLs currently redirect but may stop working in the future.

**Files updated:**
- `README.md` (2 URLs)
- `src/components/AppHeader.vue` (1 URL)
- `src/ui/options-page/app.vue` (1 URL)
- `.github/ISSUE_TEMPLATE/new-streaming-service.md` (1 URL)

No functional changes — links only.
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*