### PR TITLE
Fix: block after-credits preview auto-skip when skipAfterCredits is disabled (Crunchyroll)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 # 1.1.101
 
 - Netflix: fixed TMDB ratings, remove games, and hide title button, because of changed UI.
-- Crunchyroll: stopped skipping the after-credits preview unless "Skip to next episode" is enabled.
 
 # 1.1.100
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 1.1.101
 
 - Netflix: fixed TMDB ratings, remove games, and hide title button, because of changed UI.
+- Crunchyroll: stopped skipping the after-credits preview unless "Skip to next episode" is enabled.
 
 # 1.1.100
 

--- a/src/content-script/crunchyroll.ts
+++ b/src/content-script/crunchyroll.ts
@@ -159,6 +159,10 @@ async function startPlayOnFullScreen() {
 	}
 }
 
+export function shouldBlockPreviewSkip(ariaLabel: string | null | undefined, skipAfterCredits: boolean): boolean {
+	return !skipAfterCredits && (ariaLabel?.toLowerCase().includes("preview") ?? false)
+}
+
 // add timeout because it can skip mid sentence if language is not japanese.
 let skipped = false
 let reverseButtonClicked = false
@@ -174,11 +178,12 @@ async function Crunchyroll_Intro_Outro(video: HTMLVideoElement, time: number) {
 	// saves the audio language to settings
 	if (!reverseButtonClicked) {
 		const button = document.querySelector('button:has(svg[data-testid="skip-intro-icon"])') as HTMLElement
+		const ariaLabel = button?.getAttribute("aria-label")
 		if (
 			button &&
 			button.checkVisibility({ opacityProperty: true }) &&
 			!skipped &&
-			!button?.getAttribute("aria-label")?.toLowerCase()?.includes("recap")
+			!ariaLabel?.toLowerCase()?.includes("recap")
 		) {
 			skipped = true
 			setTimeout(function () {
@@ -191,6 +196,8 @@ async function Crunchyroll_Intro_Outro(video: HTMLVideoElement, time: number) {
 						button?.click()
 						console.log("Outro skipped", button)
 					}
+				} else if (shouldBlockPreviewSkip(ariaLabel, !!settings.value.Crunchyroll?.skipAfterCredits)) {
+					console.log("After-credits preview left alone (skipAfterCredits disabled)", button)
 				} else {
 					button?.click()
 					console.log("Intro skipped", button, settings.value.General.Crunchyroll_skipTimeout)

--- a/src/tests/content-script/crunchyroll.test.ts
+++ b/src/tests/content-script/crunchyroll.test.ts
@@ -1,9 +1,29 @@
 import { describe, it, expect } from "vitest"
-import { getEpisodeRegex } from "../../content-script/crunchyroll"
+import { getEpisodeRegex, shouldBlockPreviewSkip } from "../../content-script/crunchyroll"
 
 describe("getEpisodeRegex", () => {
 	it("Folgen 1-4 Verfügbar", () => {
 		expect("Folgen 1-4 Verfügbar".match(getEpisodeRegex)?.[1]).toBe("4")
 		expect("Folgen 1 Verfügbar".match(getEpisodeRegex)?.[1]).toBe("1")
+	})
+})
+
+describe("shouldBlockPreviewSkip", () => {
+	it("blocks the after-credits preview button when skipAfterCredits is disabled", () => {
+		expect(shouldBlockPreviewSkip("Skip Preview", false)).toBe(true)
+	})
+	it("does not block the preview button when skipAfterCredits is enabled", () => {
+		expect(shouldBlockPreviewSkip("Skip Preview", true)).toBe(false)
+	})
+	it("does not block the credits button regardless of skipAfterCredits", () => {
+		expect(shouldBlockPreviewSkip("Skip Credits", false)).toBe(false)
+		expect(shouldBlockPreviewSkip("Skip Credits", true)).toBe(false)
+	})
+	it("does not block when aria-label is missing", () => {
+		expect(shouldBlockPreviewSkip(undefined, false)).toBe(false)
+		expect(shouldBlockPreviewSkip(null, false)).toBe(false)
+	})
+	it("is case-insensitive", () => {
+		expect(shouldBlockPreviewSkip("SKIP PREVIEW", false)).toBe(true)
 	})
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -24,6 +24,16 @@ vi.mock("webextension-polyfill", () => {
 					addListener: vi.fn(),
 				},
 			},
+			sync: {
+				get: vi.fn(),
+				set: vi.fn(),
+				onChanged: {
+					addListener: vi.fn(),
+				},
+			},
+			onChanged: {
+				addListener: vi.fn(),
+			},
 		},
 	}
 })


### PR DESCRIPTION
## Summary
- Crunchyroll's after-credits "Skip Preview" button was being auto-clicked by the intro/outro skip logic even when the `skipAfterCredits` setting was disabled, since it wasn't distinguished from the regular "Skip Credits"/"Skip Intro" buttons.
- Adds a pure `shouldBlockPreviewSkip(ariaLabel, skipAfterCredits)` helper in `src/content-script/crunchyroll.ts` that detects the preview button via its `aria-label` (containing "preview") and blocks the auto-click when `skipAfterCredits` is off, leaving the button for the user to click manually.
- Also fixes a pre-existing gap in `vitest.setup.ts`: the `webextension-polyfill` mock only covered `storage.local`, so any test importing a content-script module crashed on import (`storage.sync` / `storage.onChanged` were unmocked) — all 4 content-script test files were silently reporting "0 tests". Discovered while adding coverage for this fix.

## Test plan
- [x] `vitest run src/tests/content-script/crunchyroll.test.ts` — 6/6 pass (new `shouldBlockPreviewSkip` cases: preview vs. non-preview labels, setting on/off, null `aria-label`, case-insensitivity)
- [x] `vitest run` (full suite) — 23/23 pass, 4/4 files (previously 0 tests were running in content-script test files due to the storage mock gap)
- [x] `npm run build:chrome` — builds cleanly
- [x] `npm run typecheck` / `eslint` — no new errors introduced (pre-existing errors elsewhere in the repo confirmed unchanged against the base commit)
- [x] Manual test in a real browser against crunchyroll.com with `skipAfterCredits` disabled: intro/outro skip still fires (`Intro skipped` / `IntroTimeSkipped` logged), and the after-credits "Skip Preview" button is correctly left alone (`After-credits preview left alone (skipAfterCredits disabled)` logged, button not clicked)
